### PR TITLE
Fix build on modern compilers by forcing the c++98 standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,18 @@
 PROJECT(iDSK)
 
+# See: https://stackoverflow.com/questions/10851247/how-do-i-activate-c-11-in-cmake
+macro(use_cxx98)
+  if (CMAKE_VERSION VERSION_LESS "3.1")
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+      set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++98")
+    endif ()
+  else ()
+    set (CMAKE_CXX_STANDARD 98)
+  endif ()
+endmacro(use_cxx98)
+
+use_cxx98()
+
 add_executable(iDSK
 	src/Basic.cpp
 	src/BitmapCPC.cpp


### PR DESCRIPTION
When trying to build the source code on Ubuntu 22.04 with g++ 11.3.0, it tried to use C++17 by default and triggered this error (repeated several times on other lines):

```
/tmp/idsk/src/getopt_pp.h:576:33: error: ISO C++17 does not allow dynamic exception specifications
  576 |     void end_of_options() const throw(GetOptEx)
      |                                 ^~~~~
```

The error disappears if we build with an older version of the standard, such as C++98. This patch modifies the CMake file to achieve that. I hope more people find it useful.